### PR TITLE
Some minor code linting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,13 @@
 name: Rust
 
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -11,8 +18,19 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
+      if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
     - name: Build
-      run: cargo build --verbose
+      shell: bash
+      run: RUSTFLAGS='-D warnings' cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Check formatting (if fails, fix with `cargo fmt`)
+      run: cargo fmt --all -- --check
+    - name: Check clippy lints
+      run: |
+        cargo clippy --workspace --bins --tests --lib --benches --examples -- -D warnings
+        cargo clippy --no-default-features -- -D warnings
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "static-files"
 version = "0.2.4"
 authors = ["Alexander Korolev <alexander.korolev.germany@gmail.com>"]
-edition = "2018"
+edition = "2021"
 categories = []
 description = """
 The library to help automate static resource collection.
@@ -11,16 +11,28 @@ homepage = "https://github.com/static-files-rs/static-files"
 keywords = []
 license = "Unlicense OR MIT"
 repository = "https://github.com/static-files-rs/static-files"
+rust-version = "1.60.0"
 
 [features]
-default = [ "change-detection" ]
+default = ["change-detection"]
+change-detection = ["dep:change-detection"]
 
 [dependencies]
 change-detection = { version = "1.2", optional = true }
 mime_guess = "2.0"
-path-slash = "0.1"
+path-slash = "0.2"
 
 [build-dependencies]
 change-detection = { version = "1.2", optional = true }
 mime_guess = "2.0"
-path-slash = "0.1"
+path-slash = "0.2"
+
+[lints.rust]
+unused_qualifications = "warn"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+module_name_repetitions = "allow"
+needless_doctest_main = "allow"
+struct_field_names = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "static-files"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Alexander Korolev <alexander.korolev.germany@gmail.com>"]
 edition = "2021"
 categories = []

--- a/README.md
+++ b/README.md
@@ -34,21 +34,22 @@ static-files = "0.2"
 
 Add `build.rs` with call to bundle resources:
 
-```rust#ignore
+```rust, no_run
 use static_files::resource_dir;
 
 fn main() -> std::io::Result<()> {
-    resource_dir("./static").build()?;
+    resource_dir("./static").build()
 }
 ```
 
 Include generated code in `main.rs`:
 
-```rust#ignore
+```rust, no_run
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
 fn main() -> std::io::Result<()> {
     let generated = generate(); // <-- this function is defined in generated.rs
-    ...
+    // ...
+    Ok(())
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,64 +1,9 @@
 #![doc(test(no_crate_inject))]
-/*!
-# static-files - the library to help automate static resource collection
-
-## Legal
-
-Dual-licensed under `MIT` or the [UNLICENSE](http://unlicense.org/).
-
-## Features
-
-- Embed static resources in executuble
-- Install dependencies with [npm](https://npmjs.org) package manager
-- Run custom `npm` run commands (such as [webpack](https://webpack.js.org/))
-- Support for npm-like package managers ([yarn](https://yarnpkg.com/))
-- Change detection support to reduce compilation time
-
-## Usage
-
-Create folder with static resources in your project (for example `static`):
-
-```bash
-cd project_dir
-mkdir static
-echo "Hello, world" > static/hello
-```
-
-Add to `Cargo.toml` dependency to `static-files`:
-
-```toml
-[dependencies]
-static-files = "0.2"
-
-[build-dependencies]
-static-files = "0.2"
-```
-
-Add `build.rs` with call to bundle resources:
-
-```rust#ignore
-use static_files::resource_dir;
-
-fn main() -> std::io::Result<()> {
-    resource_dir("./static").build()?;
-}
-```
-
-Include generated code in `main.rs`:
-
-```rust#ignore
-include!(concat!(env!("OUT_DIR"), "/generated.rs"));
-
-fn main() -> std::io::Result<()> {
-    let generated = generate(); // <-- this function is defined in generated.rs
-    ...
-}
-```
-*/
+#![doc = include_str!("../README.md")]
 
 mod mods;
 
-pub use mods::{
+pub use crate::mods::{
     npm_build::{npm_resource_dir, NpmBuild},
     resource::{self, Resource},
     resource_dir::{resource_dir, ResourceDir},

--- a/src/mods/resource_dir.rs
+++ b/src/mods/resource_dir.rs
@@ -1,8 +1,9 @@
-use super::sets::{generate_resources_sets, SplitByCount};
 use std::{
     env, io,
     path::{Path, PathBuf},
 };
+
+use super::sets::{generate_resources_sets, SplitByCount};
 
 /// Generate resources for `resource_dir`.
 ///
@@ -42,6 +43,9 @@ pub const DEFAULT_COUNT_PER_MODULE: usize = 256;
 
 impl ResourceDir {
     /// Generates resources for current configuration.
+    ///
+    /// # Panics
+    /// Panics if `OUT_DIR` environment variable is not set.
     pub fn build(self) -> io::Result<()> {
         let generated_filename = self.generated_filename.unwrap_or_else(|| {
             let out_dir = env::var("OUT_DIR").unwrap();
@@ -52,14 +56,14 @@ impl ResourceDir {
 
         let module_name = self
             .module_name
-            .unwrap_or_else(|| format!("{}_{}", &generated_fn, DEFAULT_MODULE_NAME));
+            .unwrap_or_else(|| format!("{generated_fn}_{DEFAULT_MODULE_NAME}"));
 
         let count_per_module = self.count_per_module.unwrap_or(DEFAULT_COUNT_PER_MODULE);
 
         generate_resources_sets(
             &self.resource_dir,
             self.filter,
-            &generated_filename,
+            generated_filename,
             module_name.as_str(),
             &generated_fn,
             &mut SplitByCount::new(count_per_module),


### PR DESCRIPTION
I tried to do some basic cleanups, but if you feel any of them are not relevant, let me know and I will revert those.

* Make CI compile on PRs and on main merge, but not on all other pushes - makes it easier to contribute
* Remove duplicate readme documentation
* Migrate to 2021 edition
* Make `change-detection` feature explicit, and use the `dep:` format
* Add lints to the Cargo.toml
* Upgrade dependencies
* Inline format var use
* Remove unneeded `&` refs
* Add a few more tests to CI